### PR TITLE
Fix typographic quotes in service worker (sw.js)

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,16 +1,16 @@
 // Medikinetics Service Worker v2
-const VERSION = ‘medikinetics-v2’;
+const VERSION = 'medikinetics-v2';
 const CACHE   = VERSION;
-const ASSETS  = [’./index.html’];
+const ASSETS  = ['./index.html'];
 
-self.addEventListener(‘install’, e => {
+self.addEventListener('install', e => {
 e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)).then(() => self.skipWaiting()));
 });
-self.addEventListener(‘activate’, e => {
+self.addEventListener('activate', e => {
 e.waitUntil(caches.keys().then(keys =>
 Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
 ).then(() => self.clients.claim()));
 });
-self.addEventListener(‘fetch’, e => {
+self.addEventListener('fetch', e => {
 e.respondWith(caches.match(e.request).then(cached => cached || fetch(e.request)));
 });


### PR DESCRIPTION
### Motivation
- Remove typographic (smart) quotes in the service worker which break JavaScript parsing and service worker behavior, and ensure the registration in `index.html` points to the corrected file.

### Description
- Replaced non-ASCII typographic quotes in `sw.js` with standard ASCII quotes for `VERSION` and `ASSETS` declarations and all `addEventListener(...)` calls (e.g. `‘`/`’` -> `'`).
- Ensured the service worker file content now uses `const VERSION = 'medikinetics-v2';` and `const ASSETS = ['./index.html'];` and standard event listener strings.
- Did not change the `index.html` registration line, only verified that `navigator.serviceWorker.register('./sw.js')` is present and correct.

### Testing
- Ran `rg -n "[‘’“”]" sw.js` to scan for remaining non-ASCII quotes and it returned no matches (success).
- Verified the service worker registration with `rg -n "navigator\.serviceWorker\.register\('./sw\.js'\)" index.html` and found the expected line (success).
- Printed `sw.js` head (`sed -n '1,80p' sw.js`) to visually confirm standard ASCII quotes are in place (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e6e083d334832db2b30686d48df654)