### PR TITLE
Improve service worker caching: app-shell assets, versioned cache, and fetch strategies

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,16 +1,166 @@
-// Medikinetics Service Worker v2
-const VERSION = ‘medikinetics-v2’;
-const CACHE   = VERSION;
-const ASSETS  = [’./index.html’];
+// Medikinetics Service Worker
+const VERSION = 'medikinetics-v3';
+const CACHE = VERSION;
 
-self.addEventListener(‘install’, e => {
-e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)).then(() => self.skipWaiting()));
+// Core app-shell files required to boot the app offline.
+const ASSETS = [
+  './',
+  './index.html',
+  // Keep likely PWA files listed so they are cached automatically once added.
+  './manifest.webmanifest',
+  './manifest.json',
+  './favicon.ico',
+  './apple-touch-icon.png',
+  './icon-192.png',
+  './icon-512.png',
+];
+
+const APP_SHELL = new Set(['./', './index.html']);
+
+self.addEventListener('install', (event) => {
+  event.waitUntil((async () => {
+    const cache = await caches.open(CACHE);
+
+    // Cache required shell first (explicit + predictable install failure if missing).
+    await cache.addAll(['./', './index.html']);
+
+    // Cache optional assets only if they exist.
+    await Promise.all(
+      ASSETS.filter((asset) => !APP_SHELL.has(asset)).map(async (asset) => {
+        try {
+          const request = new Request(asset, { cache: 'no-cache' });
+          const response = await fetch(request);
+          if (response.ok) {
+            await cache.put(request, response.clone());
+          }
+        } catch (_) {
+          // Ignore optional files that are not present yet.
+        }
+      })
+    );
+
+    await self.skipWaiting();
+  })());
 });
-self.addEventListener(‘activate’, e => {
-e.waitUntil(caches.keys().then(keys =>
-Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
-).then(() => self.clients.claim()));
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys.filter((key) => key !== CACHE).map((key) => caches.delete(key)));
+    await self.clients.claim();
+  })());
 });
-self.addEventListener(‘fetch’, e => {
-e.respondWith(caches.match(e.request).then(cached => cached || fetch(e.request)));
+
+function isNavigation(request) {
+  return request.mode === 'navigate';
+}
+
+function isExternal(url) {
+  return url.origin !== self.location.origin;
+}
+
+function isAppShellAsset(url) {
+  if (url.origin !== self.location.origin) return false;
+  const path = url.pathname;
+  return (
+    path === '/' ||
+    path === '/index.html' ||
+    path.endsWith('/index.html') ||
+    path.endsWith('/manifest.webmanifest') ||
+    path.endsWith('/manifest.json') ||
+    path.endsWith('/favicon.ico') ||
+    path.endsWith('/apple-touch-icon.png') ||
+    path.endsWith('/icon-192.png') ||
+    path.endsWith('/icon-512.png')
+  );
+}
+
+async function staleWhileRevalidate(request) {
+  const cache = await caches.open(CACHE);
+  const cached = await cache.match(request);
+  const networkPromise = fetch(request)
+    .then(async (response) => {
+      if (response && response.ok) {
+        await cache.put(request, response.clone());
+      }
+      return response;
+    })
+    .catch(() => null);
+
+  if (cached) {
+    networkPromise.catch(() => null);
+    return cached;
+  }
+
+  const network = await networkPromise;
+  if (network) return network;
+
+  return new Response('Offline', { status: 503, statusText: 'Offline' });
+}
+
+async function cacheFirst(request) {
+  const cache = await caches.open(CACHE);
+  const cached = await cache.match(request);
+  if (cached) return cached;
+
+  const response = await fetch(request);
+  if (response && response.ok) {
+    await cache.put(request, response.clone());
+  }
+  return response;
+}
+
+async function networkFirstNavigation(request) {
+  const cache = await caches.open(CACHE);
+  try {
+    const response = await fetch(request);
+    if (response && response.ok) {
+      await cache.put(request, response.clone());
+    }
+    return response;
+  } catch (_) {
+    const cachedPage = await cache.match('./index.html');
+    if (cachedPage) return cachedPage;
+    return new Response('Offline', { status: 503, statusText: 'Offline' });
+  }
+}
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  if (request.method !== 'GET') {
+    return;
+  }
+
+  if (isNavigation(request)) {
+    event.respondWith(networkFirstNavigation(request));
+    return;
+  }
+
+  if (isAppShellAsset(url)) {
+    event.respondWith(cacheFirst(request));
+    return;
+  }
+
+  if (isExternal(url)) {
+    event.respondWith(staleWhileRevalidate(request));
+    return;
+  }
+
+  // Same-origin non-shell requests: prefer fresh network, fallback to cache.
+  event.respondWith((async () => {
+    const cache = await caches.open(CACHE);
+    try {
+      const response = await fetch(request);
+      if (response && response.ok) {
+        await cache.put(request, response.clone());
+      }
+      return response;
+    } catch (_) {
+      const cached = await cache.match(request);
+      if (cached) return cached;
+      return new Response('Offline', { status: 503, statusText: 'Offline' });
+    }
+  })());
 });


### PR DESCRIPTION
### Motivation
- Make offline startup predictable by explicitly caching the required app-shell (`./`, `./index.html`) and listing common local PWA assets for automatic caching once present. 
- Serve navigations and resources with appropriate strategies so the SPA remains usable offline while external resources stay responsive and up-to-date. 
- Preserve explicit cache versioning and old-cache cleanup so updates are deliberate and predictable.

### Description
- Bump `VERSION` to `'medikinetics-v3'` and keep the cache cleanup logic in `activate` to delete old cache keys. 
- Expand `ASSETS` to include `./`, `./index.html` and common local files (`manifest.webmanifest`, `manifest.json`, `favicon.ico`, `apple-touch-icon.png`, `icon-192.png`, `icon-512.png`) and cache the required app-shell first while attempting to cache optional assets only if they exist. 
- Add helpers `isNavigation`, `isExternal`, and `isAppShellAsset` and implement fetch routing that uses: network-first for navigations with fallback to cached `index.html`, cache-first for app-shell static assets, stale-while-revalidate for third-party/external requests, and network-first (with cache fallback) for same-origin non-shell GETs. 
- Replace invalid smart quotes with standard JavaScript string delimiters and restructure install logic for predictable failures when required shell files are missing.

### Testing
- Ran `node --check sw.js` to validate JavaScript syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e6e270dbbc832d95eb8be6c5d5956e)