### PR TITLE
Add PWA manifest, icons, and update service worker to v3

### DIFF
--- a/icons/icon-128x128.svg
+++ b/icons/icon-128x128.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 100 100" role="img" aria-label="Medikinetics icon 128">
+  <rect width="100" height="100" rx="20" fill="#080d17"/>
+  <path d="M15 15 L85 85 M85 15 L15 85" stroke="#5bb8f5" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/icons/icon-144x144.svg
+++ b/icons/icon-144x144.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144" viewBox="0 0 100 100" role="img" aria-label="Medikinetics icon 144">
+  <rect width="100" height="100" rx="20" fill="#080d17"/>
+  <path d="M15 15 L85 85 M85 15 L15 85" stroke="#5bb8f5" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/icons/icon-152x152.svg
+++ b/icons/icon-152x152.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="152" height="152" viewBox="0 0 100 100" role="img" aria-label="Medikinetics icon 152">
+  <rect width="100" height="100" rx="20" fill="#080d17"/>
+  <path d="M15 15 L85 85 M85 15 L15 85" stroke="#5bb8f5" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/icons/icon-180x180.svg
+++ b/icons/icon-180x180.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="180" viewBox="0 0 100 100" role="img" aria-label="Medikinetics icon 180">
+  <rect width="100" height="100" rx="20" fill="#080d17"/>
+  <path d="M15 15 L85 85 M85 15 L15 85" stroke="#5bb8f5" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/icons/icon-192x192.svg
+++ b/icons/icon-192x192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 100 100" role="img" aria-label="Medikinetics icon 192">
+  <rect width="100" height="100" rx="20" fill="#080d17"/>
+  <path d="M15 15 L85 85 M85 15 L15 85" stroke="#5bb8f5" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/icons/icon-384x384.svg
+++ b/icons/icon-384x384.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="384" height="384" viewBox="0 0 100 100" role="img" aria-label="Medikinetics icon 384">
+  <rect width="100" height="100" rx="20" fill="#080d17"/>
+  <path d="M15 15 L85 85 M85 15 L15 85" stroke="#5bb8f5" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/icons/icon-512x512.svg
+++ b/icons/icon-512x512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 100 100" role="img" aria-label="Medikinetics icon 512">
+  <rect width="100" height="100" rx="20" fill="#080d17"/>
+  <path d="M15 15 L85 85 M85 15 L15 85" stroke="#5bb8f5" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/icons/icon-72x72.svg
+++ b/icons/icon-72x72.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="72" height="72" viewBox="0 0 100 100" role="img" aria-label="Medikinetics icon 72">
+  <rect width="100" height="100" rx="20" fill="#080d17"/>
+  <path d="M15 15 L85 85 M85 15 L15 85" stroke="#5bb8f5" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/icons/icon-96x96.svg
+++ b/icons/icon-96x96.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 100 100" role="img" aria-label="Medikinetics icon 96">
+  <rect width="100" height="100" rx="20" fill="#080d17"/>
+  <path d="M15 15 L85 85 M85 15 L15 85" stroke="#5bb8f5" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="apple-mobile-web-app-title" content="Medikinetics">
 <meta name="theme-color" content="#080d17">
+<link rel="manifest" href="./manifest.webmanifest">
+<link rel="apple-touch-icon" sizes="180x180" href="./icons/icon-180x180.svg">
+<link rel="apple-touch-icon" sizes="152x152" href="./icons/icon-152x152.svg">
 <title>Medikinetics</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Space+Grotesk:wght@600;700&display=swap" rel="stylesheet">

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,50 @@
+{
+  "name": "Medikinetics",
+  "short_name": "Medikinetics",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "theme_color": "#080d17",
+  "background_color": "#080d17",
+  "icons": [
+    {
+      "src": "./icons/icon-72x72.svg",
+      "sizes": "72x72",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "./icons/icon-96x96.svg",
+      "sizes": "96x96",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "./icons/icon-128x128.svg",
+      "sizes": "128x128",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "./icons/icon-144x144.svg",
+      "sizes": "144x144",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "./icons/icon-152x152.svg",
+      "sizes": "152x152",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "./icons/icon-192x192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "./icons/icon-384x384.svg",
+      "sizes": "384x384",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "./icons/icon-512x512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -1,16 +1,35 @@
-// Medikinetics Service Worker v2
-const VERSION = ‘medikinetics-v2’;
-const CACHE   = VERSION;
-const ASSETS  = [’./index.html’];
+// Medikinetics Service Worker v3
+const VERSION = 'medikinetics-v3';
+const CACHE = VERSION;
+const ASSETS = [
+  './index.html',
+  './manifest.webmanifest',
+  './icons/icon-72x72.svg',
+  './icons/icon-96x96.svg',
+  './icons/icon-128x128.svg',
+  './icons/icon-144x144.svg',
+  './icons/icon-152x152.svg',
+  './icons/icon-180x180.svg',
+  './icons/icon-192x192.svg',
+  './icons/icon-384x384.svg',
+  './icons/icon-512x512.svg'
+];
 
-self.addEventListener(‘install’, e => {
-e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)).then(() => self.skipWaiting()));
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE).then(cache => cache.addAll(ASSETS)).then(() => self.skipWaiting())
+  );
 });
-self.addEventListener(‘activate’, e => {
-e.waitUntil(caches.keys().then(keys =>
-Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
-).then(() => self.clients.claim()));
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then(keys => Promise.all(keys.filter(key => key !== CACHE).map(key => caches.delete(key))))
+      .then(() => self.clients.claim())
+  );
 });
-self.addEventListener(‘fetch’, e => {
-e.respondWith(caches.match(e.request).then(cached => cached || fetch(e.request)));
+
+self.addEventListener('fetch', event => {
+  event.respondWith(caches.match(event.request).then(cached => cached || fetch(event.request)));
 });


### PR DESCRIPTION
### Motivation
- Enable progressive web app support by adding a web manifest and app icons for various device sizes.
- Improve offline availability and asset caching by updating the service worker and its asset list.

### Description
- Added `manifest.webmanifest` describing app metadata and listing SVG icons for multiple sizes.
- Added a set of SVG icons under `icons/` (`72x72`, `96x96`, `128x128`, `144x144`, `152x152`, `180x180`, `192x192`, `384x384`, `512x512`).
- Updated `index.html` to include a link to `manifest.webmanifest` and `apple-touch-icon` entries for applicable sizes and kept the theme color meta.
- Upgraded `sw.js` to version `medikinetics-v3`, fixed string/quote issues and event handler syntax, and expanded the `ASSETS` cache list to include the manifest and all added icons.

### Testing
- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e6e27603dc832daeca2b785f53f0a1)