### PR TITLE
Fix PK active-dose handling across local-day rollover

### DIFF
--- a/index.html
+++ b/index.html
@@ -526,11 +526,12 @@ function render() {
   const now   = Date.now();
   const dayStart = startOfLocalDay(now);
   const today = pills.filter(p => p.takenAt >= dayStart && p.takenAt <= now);
+  const relevant = pills.filter(p => p.takenAt <= now && pillIsVisible(p, now));
 
   // Stats
   const taken    = today.reduce((s, p) => s + MEDS[p.type].totalMg, 0);
-  const inSystem = concAtTime(today, now);
-  const isRising = inSystem < 2 && today.some(p => (now - p.takenAt) < 90 * 60000);
+  const inSystem = concAtTime(relevant, now);
+  const isRising = inSystem < 2 && relevant.some(p => (now - p.takenAt) < 90 * 60000);
 
   document.getElementById('val-taken').textContent  = taken;
   document.getElementById('val-system').textContent = isRising ? '—' : inSystem.toFixed(1);
@@ -563,7 +564,7 @@ function render() {
     OFFSETS.map((o, i) => `<button class="offset-chip ${i === offsetIdx ? 'active' : ''}" onclick="setOffset(${i})">${o.label}</button>`).join('');
 
   // In progress
-  const inProgress = today.filter(p => pillIsVisible(p, now));
+  const inProgress = relevant;
   const secP = document.getElementById('section-progress');
   const cc   = document.getElementById('cards-container');
   if (inProgress.length) {
@@ -583,7 +584,7 @@ function render() {
     secL.style.display = 'none';
   }
 
-  document.getElementById('empty-state').style.display = today.length ? 'none' : '';
+  document.getElementById('empty-state').style.display = (today.length || inProgress.length) ? 'none' : '';
 }
 
 function setOffset(i) {


### PR DESCRIPTION
### Motivation
- Prevent late-night doses from being dropped from current PK/state calculations when the local calendar day rolls over while keeping the `taken today` log scoped to the local calendar day.

### Description
- In `index.html` add a `relevant` set (`const relevant = pills.filter(p => p.takenAt <= now && pillIsVisible(p, now))`) and use it for `in system` (`concAtTime(relevant, now)`), rising detection, `in progress` rendering, and empty-state visibility so pre-midnight active doses remain considered after midnight.

### Testing
- Ran `git diff --check` which passed and verified the patch locations with `rg -n "const relevant|inSystem = concAtTime\(|const inProgress =|empty-state" index.html`, which showed the expected updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e6f0304300832dae6e5eda0ce3fef8)