### PR TITLE
Phase 7: documentation cleanup and in-system units clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ One-compartment oral absorption model tuned to published methylphenidate paramet
 ## Features
 
 - Live concentration curve, updates every 30 seconds
-- Two stats: **taken today** (mg sum) and **in system** (PK model value at current time)
-- Rising indicator for the absorption phase immediately post-dose
-- Backdating via offset chips: now / -30m / -1h / -2h / -3h / -6h
+- Two stats: **taken today** (calendar-day mg sum) and **in system** (PK model estimate in mg-equivalent units — normalized to the IR reference, not plasma ng/mL)
+- Rising indicator for the absorption phase post-dose
+- Backdating via offset chips: now / -30m / -1h / -2h / -3h
+- Custom time entry and chart scrubber chip — scrub the chart to a past or future time, then log a dose at that exact moment
+- Crosshair intersection dots on the concentration curve
+- "Now" marker on the timeline
 - Undo delete, 8-second window
 - LocalStorage persistence, auto-purge after 48h
 - Service worker for offline use and update-safe caching
@@ -65,11 +68,8 @@ Two files, no build step, no dependencies.
 
 ## Planned
 
-- Fixed daily timeline window (6am–midnight)
-- “Now” marker centered on timeline
-- Crosshair intersection dots
-- Time-cursor: scrub to a point, simulate or log a dose there
-- Custom backdate input
+- Scheduled (future) dose: log a dose you plan to take, see the projected curve, confirm when taken
+- Per-dose concentration model accuracy review and unit clarification in UI
 
 -----
 

--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
     <div class="stat-divider"></div>
     <div class="stat">
       <div class="stat-val" style="color:var(--ir)">
-        <span id="val-system">0.0</span><span class="unit">mg</span>
+        <span id="val-system">0.0</span><span class="unit">mg eq</span>
       </div>
       <div class="stat-label" id="label-system">in system</div>
     </div>


### PR DESCRIPTION
## Summary

- Remove stale `-6h` offset chip from Features list
- Add scrub chip, crosshair dots, and "now" marker to Features (all implemented in Phase 4–5)
- Replace the Planned section with the actual next items (scheduled doses, PK model review)
- Clarify that "in system" is mg-equivalent units normalized to the IR reference, not plasma ng/mL — both in README and in the UI stat label (`mg` → `mg eq`)

## Test plan

- [ ] README renders correctly on GitHub
- [ ] "in system" stat shows `mg eq` suffix instead of `mg`
- [ ] No functional behaviour changes

https://claude.ai/code/session_019n1ch118zaU6BSzvSGvVEJ