### PR TITLE
Phase 8: scheduled (future) dose

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,6 +117,17 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 #undo-toast.visible { display: flex; }
 #undo-btn { background: none; border: none; color: var(--ir); font-family: 'DM Mono', monospace;
   font-size: 12px; font-weight: 700; cursor: pointer; padding: 0; letter-spacing: .06em; }
+/* Scheduled dose */
+.pill-card--scheduled { border-color: rgba(91,184,245,.25); opacity: .85; }
+.scheduled-row { display: flex; align-items: center; justify-content: space-between; margin-top: 8px; }
+.scheduled-countdown { font-family: 'DM Mono', monospace; font-size: 11px; color: var(--dim); }
+.confirm-btn { font-family: 'DM Mono', monospace; font-size: 11px; color: var(--ir);
+  background: rgba(91,184,245,.1); border: 1px solid rgba(91,184,245,.3);
+  border-radius: 8px; padding: 4px 10px; cursor: pointer; touch-action: manipulation;
+  letter-spacing: .06em; }
+.confirm-btn:active { opacity: .7; }
+.confirm-btn--inline { padding: 2px 8px; font-size: 13px; }
+.log-row--scheduled { border-left: 2px solid rgba(91,184,245,.3); padding-left: 6px; }
 </style>
 </head>
 <body>
@@ -302,8 +313,10 @@ function loadPills() {
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
-    const cutoff = Date.now() - 48 * 3600000;
-    return parsed.filter(p => p && p.takenAt > cutoff && typeof p.type === 'string' && MEDS[p.type]);
+    const now    = Date.now();
+    const cutoff  = now - 48 * 3600000;
+    const ceiling = now + 24 * 3600000;
+    return parsed.filter(p => p && p.takenAt > cutoff && p.takenAt <= ceiling && typeof p.type === 'string' && MEDS[p.type]);
   } catch (e) { console.error('MedKit: load failed', e); return []; }
 }
 
@@ -319,8 +332,9 @@ function logPill(type) {
   const rawAt = offsetIdx === SCRUB_IDX && scrubTime
     ? scrubTime.ts
     : now - OFFSETS[offsetIdx].ms;
-  const takenAt = Math.min(now, rawAt);
-  pills = [{ id: now, type, takenAt }, ...pills];
+  const isScheduled = rawAt > now;
+  const takenAt = rawAt;
+  pills = [{ id: now, type, takenAt, ...(isScheduled && { scheduled: true }) }, ...pills];
   savePills();
   offsetIdx = OFFSETS.length - 1;
   scrubTime = null;
@@ -337,6 +351,15 @@ function removePill(id) {
   if (undoTimer) clearTimeout(undoTimer);
   undoTimer = setTimeout(() => { undoItem = null; hideUndo(); }, 8000);
   showUndo(pill);
+  render();
+}
+
+function confirmPill(id) {
+  const idx = pills.findIndex(p => p.id === id);
+  if (idx === -1) return;
+  delete pills[idx].scheduled;
+  pills[idx].takenAt = Date.now();
+  savePills();
   render();
 }
 
@@ -399,7 +422,12 @@ function renderChart(today, now) {
   // Y ticks
   const yTicks = [0, Math.round(maxConc * 0.5), Math.round(maxConc)];
 
-  // Per-pill fills
+  // Split confirmed vs scheduled
+  const confirmedPills = today.filter(p => !p.scheduled);
+  const hasScheduled   = confirmedPills.length < today.length;
+  const confirmedData  = hasScheduled ? buildCurve(confirmedPills, win.start, win.end) : null;
+
+  // Per-pill fills — scheduled get lighter fill + dashed outline
   const pillFills = today.map(pill => {
     const color = MEDS[pill.type].color;
     const pts = data.map(d => ({ x: xS(d.ts), y: yS(d[pill.id] || 0) }));
@@ -408,6 +436,11 @@ function renderChart(today, now) {
       ...pts.map(p => `${p.x},${p.y}`),
       `${pts.at(-1).x},${CH}`
     ].join(' ');
+    if (pill.scheduled) {
+      const linePoly = pts.map(p => `${p.x},${p.y}`).join(' ');
+      return `<polygon points="${poly}" fill="${color}" fill-opacity="0.04"/>
+        <polyline points="${linePoly}" fill="none" stroke="${color}" stroke-width="1" stroke-opacity=".4" stroke-dasharray="4,4"/>`;
+    }
     return `<polygon points="${poly}" fill="${color}" fill-opacity="0.1"/>`;
   }).join('');
 
@@ -416,15 +449,37 @@ function renderChart(today, now) {
   const polyPts  = [`${totalPts[0].x},${CH}`, ...totalPts.map(p => `${p.x},${p.y}`), `${totalPts.at(-1).x},${CH}`].join(' ');
   const linePts  = totalPts.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x},${p.y}`).join(' ');
 
+  // When scheduled doses exist, draw confirmed-only solid line + full-total dashed overlay
+  let totalLinesSVG;
+  if (hasScheduled && confirmedData) {
+    const confPts = confirmedData.map(d => ({ x: xS(d.ts), y: yS(d.total) }));
+    const confPolyPts = [`${confPts[0].x},${CH}`, ...confPts.map(p => `${p.x},${p.y}`), `${confPts.at(-1).x},${CH}`].join(' ');
+    const confLinePts = confPts.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x},${p.y}`).join(' ');
+    totalLinesSVG = `
+      <polygon points="${confPolyPts}" fill="url(#tg)"/>
+      <path d="${linePts}" fill="none" stroke="#5bb8f5" stroke-width="1.5" stroke-opacity=".35" stroke-dasharray="5,4" stroke-linecap="round"/>
+      <path d="${confLinePts}" fill="none" stroke="#5bb8f5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>`;
+  } else {
+    totalLinesSVG = `
+      <polygon points="${polyPts}" fill="url(#tg)"/>
+      <path d="${linePts}" fill="none" stroke="#5bb8f5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>`;
+  }
+
   // Now line
   const nowX = Math.max(XPAD, Math.min(W, xS(now)));
 
-  // Phase markers — only pill ingestion moments (offsetHours === 0)
+  // Phase markers — scheduled get dashed + label
   const markers = today.map(pill => {
-    const ts = pill.takenAt; // only the moment of taking
+    const ts = pill.takenAt;
     if (ts < win.start || ts > win.end) return '';
     const x = xS(ts);
-    return `<line x1="${x}" y1="0" x2="${x}" y2="${CH}" stroke="${MEDS[pill.type].color}" stroke-width="1" stroke-opacity=".3" stroke-dasharray="2,4"/>`;
+    const color = MEDS[pill.type].color;
+    if (pill.scheduled) {
+      const lx = Math.min(x + 3, W - 28);
+      return `<line x1="${x}" y1="0" x2="${x}" y2="${CH}" stroke="${color}" stroke-width="1.5" stroke-opacity=".5" stroke-dasharray="3,3"/>
+        <text x="${lx}" y="22" font-family="'DM Mono',monospace" font-size="8" fill="${color}" fill-opacity=".7">sched</text>`;
+    }
+    return `<line x1="${x}" y1="0" x2="${x}" y2="${CH}" stroke="${color}" stroke-width="1" stroke-opacity=".3" stroke-dasharray="2,4"/>`;
   }).join('');
 
   svg.innerHTML = `
@@ -440,8 +495,7 @@ function renderChart(today, now) {
       <line x1="${XPAD}" y1="${yS(v)}" x2="${W}" y2="${yS(v)}" stroke="#1a2235" stroke-width="${v === 0 ? 1 : 0.5}"/>
     `).join('')}
     ${pillFills}
-    <polygon points="${polyPts}" fill="url(#tg)"/>
-    <path d="${linePts}" fill="none" stroke="#5bb8f5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    ${totalLinesSVG}
     ${markers}
     <line x1="${nowX}" y1="0" x2="${nowX}" y2="${CH}" stroke="#ff6b6b" stroke-width="1.5" stroke-dasharray="4,3"/>
     <text x="${Math.min(nowX + 4, W - 28)}" y="12" font-family="'DM Mono',monospace" font-size="9" fill="#ff6b6b">now</text>
@@ -523,13 +577,14 @@ function renderChart(today, now) {
 
 // ── Render ────────────────────────────────────────────────
 function render() {
-  const now   = Date.now();
-  const today = pills.filter(p => p.takenAt > now - 24 * 3600000);
+  const now       = Date.now();
+  const today     = pills.filter(p => p.takenAt > now - 24 * 3600000 || p.scheduled);
+  const confirmed = today.filter(p => !p.scheduled);
 
   // Stats
-  const taken    = today.filter(p => p.takenAt >= startOfLocalDay()).reduce((s, p) => s + MEDS[p.type].totalMg, 0);
-  const inSystem = concAtTime(today, now);
-  const isRising = inSystem < 2 && today.some(p => (now - p.takenAt) < 90 * 60000);
+  const taken    = confirmed.filter(p => p.takenAt >= startOfLocalDay()).reduce((s, p) => s + MEDS[p.type].totalMg, 0);
+  const inSystem = concAtTime(confirmed, now);
+  const isRising = inSystem < 2 && confirmed.some(p => (now - p.takenAt) < 90 * 60000);
 
   document.getElementById('val-taken').textContent  = taken;
   document.getElementById('val-system').textContent = isRising ? '—' : inSystem.toFixed(1);
@@ -600,7 +655,29 @@ function selectScrubChip() {
 }
 
 function pillCardHTML(pill, now) {
-  const def     = MEDS[pill.type];
+  const def = MEDS[pill.type];
+
+  if (pill.scheduled) {
+    const overdue    = pill.takenAt <= now;
+    const timeStr    = overdue ? 'overdue' : `in ${durStr(pill.takenAt - now) ?? 'soon'}`;
+    const statusColor = overdue ? 'var(--cr)' : 'var(--ir)';
+    return `
+    <div class="pill-card pill-card--scheduled">
+      <div class="card-head">
+        <div class="card-head-left">
+          <span class="card-type" style="color:${def.color}">${def.label}</span>
+          <span class="card-mg">${def.totalMg} mg</span>
+          <span class="card-time" style="color:${statusColor}">${fmt(pill.takenAt)}</span>
+        </div>
+        <button class="x-btn" onclick="removePill(${pill.id})">×</button>
+      </div>
+      <div class="scheduled-row">
+        <span class="scheduled-countdown" style="color:${statusColor}">${timeStr}</span>
+        <button class="confirm-btn" onclick="confirmPill(${pill.id})">confirm taken</button>
+      </div>
+    </div>`;
+  }
+
   const allDone = def.phases.every(ph => phaseStatus(ph, pill.takenAt, now) === 'done');
 
   let body;
@@ -655,7 +732,23 @@ function pillCardHTML(pill, now) {
 }
 
 function logRowHTML(pill, now) {
-  const def      = MEDS[pill.type];
+  const def = MEDS[pill.type];
+
+  if (pill.scheduled) {
+    const overdue     = pill.takenAt <= now;
+    const statusText  = overdue ? 'overdue' : 'scheduled';
+    const statusColor = overdue ? 'var(--cr)' : 'var(--ir)';
+    return `
+    <div class="log-row log-row--scheduled">
+      <span class="log-type" style="color:${def.color}">${def.label}</span>
+      <span class="log-mg">${def.totalMg} mg</span>
+      <span class="log-t">${fmt(pill.takenAt)}</span>
+      <span class="log-status" style="color:${statusColor}">${statusText}</span>
+      <button class="confirm-btn confirm-btn--inline" onclick="confirmPill(${pill.id})">✓</button>
+      <button class="x-btn" onclick="removePill(${pill.id})">×</button>
+    </div>`;
+  }
+
   const visible  = pillIsVisible(pill, now);
   const conc     = concAtTime([pill], now);
   const rising   = conc < 2 && (now - pill.takenAt) < 90 * 60000;
@@ -684,8 +777,7 @@ document.getElementById('manual-time-input').addEventListener('change', e => {
   const [h, m] = val.split(':').map(Number);
   const d = new Date();
   d.setHours(h, m, 0, 0);
-  // if the resulting time is in the future, assume yesterday
-  const ts = d.getTime() > Date.now() ? d.getTime() - 86400000 : d.getTime();
+  const ts = d.getTime(); // future times allowed — will log as scheduled dose
   scrubTime = { ts, label: val };
   offsetIdx = SCRUB_IDX;
   document.getElementById('time-input-row').style.display = 'none';

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Medikinetics Service Worker v2
-const VERSION = 'medikinetics-v2';
+// Medikinetics Service Worker v3
+const VERSION = 'medikinetics-v3';
 const CACHE   = VERSION;
 const ASSETS  = ['./index.html'];
 


### PR DESCRIPTION
## Summary

- **Scheduled dose**: scrub to a future time and tap a dose button — pill is logged with `scheduled: true` instead of clamping `takenAt` to now
- **Chart projection**: scheduled pills render as a dashed curve extension; when scheduled doses exist, the confirmed-total is drawn solid and the full projected total is overlaid as a faint dashed line
- **In-progress card**: shows scheduled time, overdue state, and a "confirm taken" button
- **Log row**: shows `scheduled` / `overdue` status with an inline `✓` confirm button
- **Confirm flow**: `confirmPill(id)` removes the `scheduled` flag and sets `takenAt = Date.now()` (actual ingestion time)
- **Stats**: taken-today and in-system exclude unconfirmed scheduled doses
- **Manual time input**: future times now allowed — no longer rolls back to yesterday
- **loadPills()**: ceiling guard (now + 24 h) rejects absurd far-future entries on load
- **sw.js**: bumped to `medikinetics-v3` so cached clients receive the update

## Test plan

- [ ] Scrub to a future time → tap IR → dose appears in log as "scheduled · HH:MM", in "in progress" with confirm button, on chart as dashed extension
- [ ] "Taken today" and "in system" stats are unchanged by the scheduled dose
- [ ] Tap "confirm taken" → dose becomes normal, chart solid curve rises, `takenAt` = now
- [ ] Tap × on a scheduled dose → removed with undo toast (8 s window)
- [ ] Scheduled dose with a past `takenAt` shows "overdue" in amber in both card and log row
- [ ] Manual time input set to a future time → logs as scheduled (no rollback to yesterday)
- [ ] Reload the page → scheduled dose persists (loadPills ceiling guard admits up to +24 h)

https://claude.ai/code/session_011rcdRePtYLir8NzekUMFfd