### PR TITLE
Phase 9: PK slope for isRising, remove clearing bar, add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# Medikinetics — Claude Code context
+
+## What this is
+A single-file PWA (`index.html` + `sw.js`) for tracking methylphenidate pharmacokinetics.
+One-compartment oral absorption model (Bateman equation). No build step, no framework.
+Deployed on GitHub Pages; test target is Safari on iPhone.
+
+## Current state
+Check `git log` for the latest. Phases completed so far:
+- Phases 1–5: bug fixes, smarter graph window, crosshair dots, unified scrub/time chip, PK-threshold pill visibility, clearing cards
+- Phase 6: graph window anchored to today's midnight; "taken today" = calendar day
+- Phase 7: README cleanup; "in system" label → "mg eq"
+- Phase 8: dose simulation / preview (ephemeral, never persisted)
+- Phase 9: isRising uses PK slope; clearing bar removed; this file added
+
+## Key architectural decisions
+- Single-file: all app logic lives in `index.html`. Keep it that way.
+- PK model: Bateman equation, KE=0.347, KA=2.0 (IR), KA=0.7 (CR delayed phase)
+- Simulation is ephemeral (`simulatedPills` array, never saved) — not "scheduled doses"
+- Graph window left edge anchors to today's midnight; PK curve uses 24h rolling filter
+- "taken today" stat uses `startOfLocalDay()`; PK curve uses rolling 24h
+
+## Workflow — follow exactly
+1. Read `git log` and recent merged PRs to understand current state before starting
+2. Create a dedicated branch for each feature or fix
+3. Open a PR — do not merge yourself, wait for user approval
+4. Never push directly to main
+5. Never infer upcoming work from `README.md` — the README describes what is built, not what comes next. Ask the user what to do next.
+
+## Medications modelled
+| Label | Drug | Dose | Phases |
+|-------|------|------|--------|
+| IR ½ | Methylphenidate IR | 5mg | Single phase, ka=2.0 |
+| IR | Methylphenidate IR | 10mg | Single phase, ka=2.0 |
+| CR | Methylphenidate CR | 20mg | 10mg at 0h (ka=2.0) + 10mg at +4h (ka=0.7) |

--- a/index.html
+++ b/index.html
@@ -574,7 +574,7 @@ function render() {
   // Stats
   const taken    = today.filter(p => p.takenAt >= startOfLocalDay()).reduce((s, p) => s + MEDS[p.type].totalMg, 0);
   const inSystem = concAtTime(today, now);
-  const isRising = inSystem < 2 && today.some(p => (now - p.takenAt) < 90 * 60000);
+  const isRising = concAtTime(today, now + 5 * 60000) > inSystem;
 
   document.getElementById('val-taken').textContent  = taken;
   document.getElementById('val-system').textContent = isRising ? '—' : inSystem.toFixed(1);
@@ -669,7 +669,6 @@ function pillCardHTML(pill, now) {
   let body;
   if (allDone) {
     const conc      = concAtTime([pill], now);
-    const pct       = Math.min(100, (conc / def.totalMg) * 100);
     const threshold = def.totalMg * 0.1;
     const minsLeft  = conc > threshold ? Math.round((Math.log(conc / threshold) / KE) * 60) : 0;
     const timeStr   = durStr(minsLeft * 60000) ?? '—';
@@ -679,7 +678,6 @@ function pillCardHTML(pill, now) {
           <span class="phase-mg" style="color:var(--soft)">clearing · ${conc.toFixed(1)} mg eq</span>
           <span class="phase-time">${timeStr} left</span>
         </div>
-        <div class="track"><div class="fill-bar" style="width:${pct}%;background:var(--soft)"></div></div>
       </div>`;
   } else {
     body = def.phases.map((ph, i) => {
@@ -721,7 +719,7 @@ function logRowHTML(pill, now) {
   const def      = MEDS[pill.type];
   const visible  = pillIsVisible(pill, now);
   const conc     = concAtTime([pill], now);
-  const rising   = conc < 2 && (now - pill.takenAt) < 90 * 60000;
+  const rising   = concAtTime([pill], now + 5 * 60000) > conc;
   const allDone  = def.phases.every(ph => phaseStatus(ph, pill.takenAt, now) === 'done');
   const clearing = visible && allDone;
   const st = !visible ? 'done' : rising ? '↑ rising' : clearing ? 'clearing' : 'active';


### PR DESCRIPTION
## Summary

- **`isRising` fix**: replaces `inSystem < 2 && takenAt < 90min` with `concAtTime(now+5m) > inSystem`. No magic constants, model-correct, and properly detects CR second-phase rising (previously suppressed when `inSystem` was already > 2 from the first peak)
- **`rising` in log rows**: same slope fix applied per-pill
- **Clearing bar removed**: the bar during the clearing state spanned only ~10–25% width (conc/totalMg), too thin to read. Replaced with text-only: `clearing · X.X mg eq · Xh Xm left`
- **`CLAUDE.md` added**: session-start context file for Claude Code — documents project state, key architectural decisions, and an explicit rule not to infer upcoming work from README

## Test plan

- [ ] Log a CR dose; after ~4h the "in system" stat shows `↑ rising` as the second bead phase activates
- [ ] Log an IR dose from 6+ hours ago: card shows `clearing · X.X mg eq · Xh Xm left` with no progress bar below it
- [ ] No false `↑ rising` with no doses logged (`isRising = false` when `today` is empty — both sides of the comparison are 0)
- [ ] Open a new Claude Code session on the repo: CLAUDE.md is read and session correctly describes project state

https://claude.ai/code/session_019n1ch118zaU6BSzvSGvVEJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019n1ch118zaU6BSzvSGvVEJ)_