### PR TITLE
Always show concentration number; keep rising label for direction

### DIFF
--- a/index.html
+++ b/index.html
@@ -577,7 +577,7 @@ function render() {
   const isRising = concAtTime(today, now + 5 * 60000) > inSystem;
 
   document.getElementById('val-taken').textContent  = taken;
-  document.getElementById('val-system').textContent = isRising ? '—' : inSystem.toFixed(1);
+  document.getElementById('val-system').textContent = inSystem.toFixed(1);
   document.getElementById('label-system').innerHTML = isRising
     ? '<span style="color:#94b8d4">↑ rising</span>'
     : 'in system';


### PR DESCRIPTION
The '—' placeholder during absorption hid the most useful information
at the most relevant moment. The ↑ rising label already signals direction;
showing the actual mg eq value alongside it gives the complete picture.

https://claude.ai/code/session_01GzUqhFDs6c6nMfYSBac99p