### PR TITLE
Fix Bateman equal-rate limit

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,7 +220,9 @@ const NORM = 1 / _cm;
 
 function phaseConc(mg, tH, ka) {
   if (tH < 0) return 0;
-  if (Math.abs(ka - KE) < 0.001) return 0;
+  if (Math.abs(ka - KE) < 0.001) {
+    return Math.max(0, mg * NORM * KE * tH * Math.exp(-KE * tH));
+  }
   return Math.max(0, mg * NORM * (ka / (ka - KE)) * (Math.exp(-KE * tH) - Math.exp(-ka * tH)));
 }
 


### PR DESCRIPTION
Summary
Fix one isolated mathematical edge case in the PK model without changing the current IR or CR curves.

The current app returns 0 when absorption rate ka is almost equal to elimination rate KE. The correct Bateman limit is a real curve. This does not affect today’s constants (ka=2.0, ka=0.7, KE=0.347), so this is a low-risk trust-building change.

Key Changes
Create branch codex/fix-bateman-limit.
Edit only index.html, inside phaseConc.
Replace the current near-equal branch: with the Bateman limit:
Do not change KE, KA_REF, med definitions, README wording, storage, UI, graph logic, or service worker.
Test Plan
Run a small local calculation comparing old vs new output for current app constants:
IR 10mg with ka=2.0
CR delayed phase with ka=0.7
Times: 0, 0.5, 1, 2, 4, 6, 8 hours
Acceptance: all current-constant outputs are unchanged.
Verify the fixed edge case:
phaseConc(10, 2, KE) should become about 5.0078 instead of 0.
Do a quick browser smoke check:
app loads
IR/CR buttons still log doses
graph renders
“mg eq” value updates
