### PR TITLE
Recolor CR to lavender; simplify button sublabels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Check `git log` for the latest. Phases completed so far:
 - Phase 9: isRising uses PK slope; clearing bar removed; this file added
 - Phase 10: Bateman equal-rate limit fix (PR #19); fasted CR model (single phase 20mg ka=1.0, default); per-dose fed/fasted toggle chip on pill cards; GitHub Issues workflow established
 - UX pass (PRs #23–#29): design tokens, Space Grotesk + DM Mono typography, interactive affordances, scale-transform press feedback (JS touchstart handler for iOS), undo toast drain bar, fed/fasted chip → toggle switch (direct DOM update in toggleFed for CSS transition), silent debounce → 400ms `.just-fired` disable, CR orange muted (#f5a050 → #b08860), double-tap zoom prevention
+- Color clarification (PRs #33–#34): dose button borders → neutral --muted; fed toggle → --green; CR recolored to lavender (#9d7fd4); button sublabels simplified to "5mg" / "10mg" / "20mg"
 
 ## Key architectural decisions
 - Single-file: all app logic lives in `index.html`. Keep it that way.
@@ -25,7 +26,7 @@ Check `git log` for the latest. Phases completed so far:
 - `html, body` has `touch-action: manipulation` — blocks iOS double-tap zoom globally without disabling pinch zoom
 - `.pill-card` carries `data-id="${pill.id}"`. `toggleFed()` updates toggle DOM directly (class toggles on `.fed-track` and `.fed-lbl` only) then calls `renderChart()` + stats inline — does NOT call `render()`, so the `.2s` CSS slide transition plays on the thumb
 - Dose button debounce removed. After a real log, all `.dose-btn` get `disabled` + `.just-fired` (opacity .35) for 400ms. The `touchstart` handler skips `disabled` elements — feedback and action stay in sync
-- `--cr: #b08860` (muted warm brown); `--clearing: #7a6248`. `MEDS.CR.color` must match `--cr`
+- `--cr: #9d7fd4` (lavender/violet); `--clearing: #614f8a`. `MEDS.CR.color` must match `--cr`
 
 ## Workflow — follow exactly
 1. Read `git log` and recent merged PRs to understand current state before starting

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 :root {
   --bg: #080d17; --surface: #0f1623; --border: #1a2235;
   --muted: #2d3f57; --dim: #3a5070; --soft: #4a6080;
-  --text: #dce8f5; --ir: #5bb8f5; --cr: #b08860; --green: #4ecb8d;
-  --now: #ff6b6b; --clearing: #7a6248; --rising: #94b8d4;
+  --text: #dce8f5; --ir: #5bb8f5; --cr: #9d7fd4; --green: #4ecb8d;
+  --now: #ff6b6b; --clearing: #614f8a; --rising: #94b8d4;
   --toast-text: #8ba3be; --tooltip-bg: #0a1020;
   --safe-top: env(safe-area-inset-top, 0px);
   --safe-bot: env(safe-area-inset-bottom, 0px);
@@ -220,11 +220,11 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 <script>
 // ── Med definitions ──────────────────────────────────────
 const MEDS = {
-  IRH: { label: 'IR ½', sublabel: '5mg split',     totalMg: 5,  color: '#5bb8f5',
+  IRH: { label: 'IR',   sublabel: '5mg',           totalMg: 5,  color: '#5bb8f5',
          phases: [{ offsetHours: 0, mg: 5,  durationHours: 4, ka: 2.0 }] },
-  IR:  { label: 'IR',   sublabel: 'Medikinet 10mg', totalMg: 10, color: '#5bb8f5',
+  IR:  { label: 'IR',   sublabel: '10mg',          totalMg: 10, color: '#5bb8f5',
          phases: [{ offsetHours: 0, mg: 10, durationHours: 4, ka: 2.0 }] },
-  CR:  { label: 'CR',   sublabel: 'Medikinet 20mg', totalMg: 20, color: '#b08860',
+  CR:  { label: 'CR',   sublabel: '20mg',          totalMg: 20, color: '#9d7fd4',
          phases:       [{ offsetHours: 0, mg: 10, durationHours: 4, ka: 2.0 },
                         { offsetHours: 4, mg: 10, durationHours: 4, ka: 0.7 }],
          // ka=1.0: judgment call — ER beads release early without food but bead matrix

--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 <div id="app">
   <div class="header">
     <div class="title">Medikinetics</div>
-    <div class="sub">Medikinet IR · CR <span style="opacity:.4">· 20260425.1857</span></div>
+    <div class="sub"><span style="opacity:.4">20260425.1857</span></div>
   </div>
 
   <div class="stats-row">


### PR DESCRIPTION
--cr: #b08860 → #9d7fd4 (lavender/violet)
--clearing: #7a6248 → #614f8a (muted darker lavender)
MEDS.CR.color updated to match --cr

Button sublabels stripped of brand copy:
  IRH: "5mg split" → "5mg"
  IR:  "Medikinet 10mg" → "10mg"
  CR:  "Medikinet 20mg" → "20mg"
IRH.label: "IR ½" → "IR" (dose is already in sublabel)

https://claude.ai/code/session_017EaM9TMkyporhjraAseGQV