### PR TITLE
Button label cleanup + neutral dose buttons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Check `git log` for the latest. Phases completed so far:
 - Phase 9: isRising uses PK slope; clearing bar removed; this file added
 - Phase 10: Bateman equal-rate limit fix (PR #19); fasted CR model (single phase 20mg ka=1.0, default); per-dose fed/fasted toggle chip on pill cards; GitHub Issues workflow established
 - UX pass (PRs #23–#29): design tokens, Space Grotesk + DM Mono typography, interactive affordances, scale-transform press feedback (JS touchstart handler for iOS), undo toast drain bar, fed/fasted chip → toggle switch (direct DOM update in toggleFed for CSS transition), silent debounce → 400ms `.just-fired` disable, CR orange muted (#f5a050 → #b08860), double-tap zoom prevention
-- Color clarification (PRs #33–#34): dose button borders → neutral --muted; fed toggle → --green; CR recolored to lavender (#9d7fd4); button sublabels simplified to "5mg" / "10mg" / "20mg"
+- Color clarification (PRs #33–#34): dose button borders → neutral --muted; fed toggle → --green; CR recolored to lavender (#9d7fd4); button sublabels simplified to "5mg" / "10mg" / "20mg"; dose buttons neutral (no type color — color lives on graph + cards only)
 
 ## Key architectural decisions
 - Single-file: all app logic lives in `index.html`. Keep it that way.

--- a/index.html
+++ b/index.html
@@ -650,7 +650,6 @@ function render() {
     Object.entries(MEDS).forEach(([type, def]) => {
       const btn = document.createElement('button');
       btn.className = 'dose-btn';
-      btn.style.color = def.color;
       btn.innerHTML = `<span class="dose-btn-name">${def.label}</span><span class="dose-btn-sub">${def.sublabel}</span>`;
       btn.onclick = () => logPill(type);
       dg.appendChild(btn);


### PR DESCRIPTION
Picks up where PR #33 left off — lavender CR color wasn't included in that merge, plus two new changes from this session.

## Changes

- **CR → lavender** (`--cr: #b08860` → `#9d7fd4`, `--clearing` updated to match); `MEDS.CR.color` in sync
- **Button sublabels** stripped of brand copy: `5mg split` → `5mg`, `Medikinet 10mg` → `10mg`, `Medikinet 20mg` → `20mg`; `IR ½` → `IR` (dose is already in sublabel)
- **"Medikinet IR · CR"** subtitle removed from header
- **Dose buttons neutral** — `btn.style.color` override removed; type color (cyan/lavender) now lives only on graph curves and pill card type labels where it encodes real information

## Related

Issue #35 opened for colorblind accessibility follow-up (cyan vs lavender may be indistinguishable for deuteranopes).

https://claude.ai/code/session_017EaM9TMkyporhjraAseGQV

---
_Generated by [Claude Code](https://claude.ai/code/session_017EaM9TMkyporhjraAseGQV)_