### PR TITLE
Remove stale accessibility section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,6 @@ One-compartment oral absorption model tuned to published methylphenidate paramet
 
 -----
 
-## Accessibility
-
-Blue (`#5bb8f5`) for IR doses, warm brown (`#b08860`) for CR — selected for deutan (red-green) color vision deficiency.
-
------
-
 ## Self-hosting
 
 Two files, no build step, no dependencies.


### PR DESCRIPTION
## What changed
Removes the Accessibility section from README, which referenced warm brown (`#b08860`) for CR — a color that was replaced with lavender (`#9d7fd4`) in PRs #33–34.

## Why
The section was factually wrong and the underlying accessibility problem is unresolved. Updates #35.

## Checklist
- [x] README updated if user-visible behaviour or project structure changed — yes, stale section removed
- [x] AGENTS.md updated if a new architectural decision was made — no new decisions
- [x] Decision Log entry added for any judgment call — no judgment calls
- [x] Commit messages use conventional prefix (feat/fix/docs/chore) — `docs:`

---
_Generated by [Claude Code](https://claude.ai/code/session_019tKxvp4N9LmxRKWjkfqMkH)_