### PR TITLE
fix: resolve offline PWA launch blank screen on GitHub Pages

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,16 +1,31 @@
-// Medikinetics Service Worker v3
-const VERSION = 'medikinetics-20260426.1643';
+// Medikinetics Service Worker v4
+const VERSION = 'medikinetics-20260430.0001';
 const CACHE   = VERSION;
-const ASSETS  = ['./index.html'];
+const ASSETS  = ['./', './index.html'];
 
 self.addEventListener('install', e => {
-e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)).then(() => self.skipWaiting()));
+  e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)).then(() => self.skipWaiting()));
 });
+
 self.addEventListener('activate', e => {
-e.waitUntil(caches.keys().then(keys =>
-Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
-).then(() => self.clients.claim()));
+  e.waitUntil(
+    caches.keys()
+      .then(keys => Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k))))
+      .then(() => self.clients.claim())
+  );
 });
+
 self.addEventListener('fetch', e => {
-e.respondWith(caches.match(e.request).then(cached => cached || fetch(e.request)));
+  if (e.request.mode === 'navigate') {
+    e.respondWith(
+      fetch(e.request).catch(async () => {
+        const cachedRoot = await caches.match('./');
+        if (cachedRoot) return cachedRoot;
+        return caches.match('./index.html');
+      })
+    );
+    return;
+  }
+
+  e.respondWith(caches.match(e.request).then(cached => cached || fetch(e.request)));
 });


### PR DESCRIPTION
### Motivation
- Offline PWA launches from GitHub Pages could show a blank white screen because navigation requests were not served from the cached app shell.  
- The fix must preserve the single-file app architecture (`index.html` + `sw.js`) and existing cache lifecycle while enabling offline navigation fallback.

### Description
- Bumped `VERSION` in `sw.js` and added `./` alongside `./index.html` to the precache `ASSETS` so the app shell is cached for root navigations.  
- Added a navigation-specific `fetch` handler that tries network first and falls back to the cached `./` and then `./index.html` when offline.  
- Preserved cache versioning and old-cache cleanup by keeping `CACHE = VERSION` and deleting non-current caches on `activate`.  
- Closes #42 and includes manual iPhone/Safari PWA validation steps: open `https://<user>.github.io/medikinetics/` in Safari on iPhone, `Add to Home Screen` and launch once online, enable Airplane Mode (or disable network), launch the installed app from Home Screen and confirm the UI loads (no blank white screen), optionally kill and reopen again offline, then re-enable network to confirm normal behavior.

### Testing
- Ran `node --check sw.js` to validate service worker syntax and it succeeded.  
- No additional automated test suite exists for this change; manual iPhone/Safari validation steps are provided above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f3a3e85634832da80c4003c26e80c4)