### PR TITLE
fix: harden service worker respondWith fallback for offline launches

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,31 +1,145 @@
-// Medikinetics Service Worker v4
-const VERSION = 'medikinetics-20260430.0001';
-const CACHE   = VERSION;
-const ASSETS  = ['./', './index.html'];
+// Medikinetics Service Worker v5
+const VERSION = 'medikinetics-20260430.0003';
+const CACHE = VERSION;
 
-self.addEventListener('install', e => {
-  e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)).then(() => self.skipWaiting()));
-});
+const APP_ROOT = self.registration.scope;
+const APP_SHELL = new URL('index.html', APP_ROOT).href;
 
-self.addEventListener('activate', e => {
-  e.waitUntil(
-    caches.keys()
-      .then(keys => Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k))))
-      .then(() => self.clients.claim())
+const OFFLINE_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Medikinetics offline</title>
+<style>
+  html, body {
+    margin: 0;
+    height: 100%;
+    background: #080d17;
+    color: #dce8f5;
+    font-family: system-ui, sans-serif;
+  }
+  body {
+    display: grid;
+    place-items: center;
+    padding: 24px;
+    text-align: center;
+  }
+  main {
+    max-width: 320px;
+  }
+  h1 {
+    font-size: 20px;
+    margin-bottom: 8px;
+  }
+  p {
+    color: #8ba3be;
+    line-height: 1.45;
+  }
+</style>
+</head>
+<body>
+<main>
+  <h1>Medikinetics is offline</h1>
+  <p>The app shell was not cached yet. Open Medikinetics once while online, then try again offline.</p>
+</main>
+</body>
+</html>`;
+
+function offlineResponse() {
+  return new Response(OFFLINE_HTML, {
+    status: 200,
+    headers: { 'Content-Type': 'text/html; charset=utf-8' }
+  });
+}
+
+async function putShell(response) {
+  const cache = await caches.open(CACHE);
+  await cache.put(APP_SHELL, response.clone());
+  await cache.put(APP_ROOT, response.clone());
+}
+
+async function getCachedShell(request) {
+  const cache = await caches.open(CACHE);
+
+  return (
+    await cache.match(request, { ignoreSearch: true }) ||
+    await cache.match(APP_ROOT) ||
+    await cache.match(APP_SHELL)
   );
+}
+
+async function fetchAndCacheShell(request) {
+  const response = await fetch(request, { cache: 'reload' });
+
+  if (!response || !response.ok) {
+    throw new Error(`Shell fetch failed: ${response && response.status}`);
+  }
+
+  await putShell(response);
+  return response;
+}
+
+self.addEventListener('install', event => {
+  event.waitUntil((async () => {
+    const response = await fetch(APP_SHELL, { cache: 'reload' });
+
+    if (!response || !response.ok) {
+      throw new Error(`Install shell fetch failed: ${response && response.status}`);
+    }
+
+    await putShell(response);
+    await self.skipWaiting();
+  })());
 });
 
-self.addEventListener('fetch', e => {
-  if (e.request.mode === 'navigate') {
-    e.respondWith(
-      fetch(e.request).catch(async () => {
-        const cachedRoot = await caches.match('./');
-        if (cachedRoot) return cachedRoot;
-        return caches.match('./index.html');
-      })
+self.addEventListener('activate', event => {
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+
+    await Promise.all(
+      keys
+        .filter(key => key !== CACHE)
+        .map(key => caches.delete(key))
     );
+
+    await self.clients.claim();
+  })());
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+
+  if (event.request.mode === 'navigate') {
+    event.respondWith((async () => {
+      try {
+        const cached = await getCachedShell(event.request);
+
+        if (cached) {
+          event.waitUntil(
+            fetchAndCacheShell(event.request).catch(() => null)
+          );
+
+          return cached;
+        }
+
+        return await fetchAndCacheShell(event.request);
+      } catch (error) {
+        return offlineResponse();
+      }
+    })());
+
     return;
   }
 
-  e.respondWith(caches.match(e.request).then(cached => cached || fetch(e.request)));
+  event.respondWith((async () => {
+    try {
+      const cached = await caches.match(event.request);
+      if (cached) return cached;
+
+      return await fetch(event.request);
+    } catch (error) {
+      return new Response('', { status: 504, statusText: 'Offline' });
+    }
+  })());
 });


### PR DESCRIPTION
### Motivation
- Fix a crash on iOS Safari Home Screen where the service worker navigation handler could let `respondWith()` resolve to `undefined` or reject (manifesting as `FetchEvent.respondWith received an error: TypeError: Load failed`).
- Make navigation handling impossible to fail even when network is down and the cache is empty while preserving the single-file app architecture and versioned cache cleanup.

### Description
- Bumped `VERSION` to `medikinetics-20260430.0003` and switched navigation strategy to cache-first with background refresh so an existing cached shell is returned immediately and refreshed in the background via `fetchAndCacheShell`.
- Added `APP_ROOT = self.registration.scope` and `APP_SHELL = new URL('index.html', APP_ROOT).href`, and now cache the app shell under both keys using `putShell`, plus implemented `getCachedShell` to search the cache robustly.
- Updated `install` to fetch `APP_SHELL` with `cache: 'reload'`, verify `response.ok`, cache it, and call `skipWaiting()`, and preserved versioned cache cleanup and `clients.claim()` in `activate`.
- Added `offlineResponse()` inline emergency HTML fallback for navigations and a non-navigation GET fallback that returns a concrete `504 Response` instead of throwing, and noted that PR #45 was insufficient because the previous navigation handler could still return `undefined`/reject; Closes #42; iPhone/Safari validation steps: turn network on, open the GitHub Pages URL in Safari and reload once or twice, wait a few seconds, open the Home Screen app once while online, kill the app, enable Airplane Mode, reopen from Home Screen, and confirm the UI loads or at minimum the emergency offline page appears instead of Safari’s `FetchEvent.respondWith` TypeError.

### Testing
- Automated parse/check: `node --check sw.js` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f3aa2e75c4832d844b3963e3fca082)