### PR TITLE
perf: memoize buildCurve; replace O(n) tooltip reduce with binary search

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,7 +265,11 @@ function concAtTime(pills, ts) {
   return total;
 }
 
+let _curveCache = null;
 function buildCurve(pills, wStart, wEnd) {
+  const key = `${wStart}|${wEnd}|${pills.map(p => `${p.id}:${p.type}:${p.takenAt}:${p.fed ? 1 : 0}`).join(',')}`;
+  if (_curveCache?.key === key) return _curveCache.result;
+
   const pts = [];
   for (let ts = wStart; ts <= wEnd; ts += 10 * 60000) {
     let total = 0;
@@ -279,7 +283,18 @@ function buildCurve(pills, wStart, wEnd) {
     }
     pts.push({ ts, total: Math.round(total * 10) / 10, ...perPill });
   }
+  _curveCache = { key, result: pts };
   return pts;
+}
+
+function closestPoint(data, ts) {
+  let lo = 0, hi = data.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (data[mid].ts < ts) lo = mid + 1; else hi = mid;
+  }
+  if (lo > 0 && Math.abs(data[lo - 1].ts - ts) <= Math.abs(data[lo].ts - ts)) return data[lo - 1];
+  return data[lo];
 }
 
 function getCurveWindow(pills, now) {
@@ -582,8 +597,7 @@ function renderChart(today, simulated, now) {
     const relX = clientX - rect.left - XPAD;
     const fracX = Math.max(0, Math.min(1, relX / CW));
     const ts = win.start + fracX * (win.end - win.start);
-    const closest = data.reduce((best, p) =>
-      Math.abs(p.ts - ts) < Math.abs(best.ts - ts) ? p : best);
+    const closest = closestPoint(data, ts);
     const cx = XPAD + fracX * CW;
     crosshair.setAttribute('x1', cx);
     crosshair.setAttribute('x2', cx);


### PR DESCRIPTION
## Summary

- **`buildCurve` memoization** — Added a single-slot cache keyed on the full argument fingerprint: `${wStart}|${wEnd}|${pills.map(p => id:type:takenAt:fed).join(',')}`. The 30-second render tick now short-circuits when pills and window are unchanged — the O(pills × phases × points) computation only runs after a real mutation. Cache invalidates naturally on any state change; no manual flush needed.

- **Binary search in `showTooltip`** — `data.reduce()` (O(n) per mousemove/touchmove) replaced with `closestPoint(data, ts)` which bisects the sorted-by-`ts` array in O(log n) — ~7 comparisons for the typical 144-point window. The boundary check (`lo > 0 && abs(lo-1) <= abs(lo)`) correctly handles ties.

No behavior changes — both optimizations are pure algorithmic substitutions.

## Test plan

- [ ] Drag chart crosshair — tooltip updates correctly at all positions including edges
- [ ] Log a dose — chart rebuilds with new pill curve
- [ ] Wait 30s without action — render tick completes without visible jank
- [ ] Toggle fed/fasted on CR pill — chart updates correctly (cache key includes `fed` flag)
- [ ] Remove a pill — chart updates correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)