### PR TITLE
feat: SW hardening — cache-on-first-use for all assets; update banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,6 +144,10 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
   font-size: 12px; font-weight: 700; cursor: pointer; padding: 0; letter-spacing: .06em;
   transition: transform .15s ease-out; }
 #undo-btn.pressing, #undo-btn:active { transform: scale(0.88); transition: transform .08s ease-in; }
+/* Simulation card */
+.pill-card--sim { border-color: rgba(91,184,245,.2); border-style: dashed; opacity: .8; }
+.sim-label { font-family: 'DM Mono', monospace; font-size: 10px; color: var(--dim);
+  text-transform: uppercase; letter-spacing: .06em; margin-top: 6px; }
 /* Update banner */
 #update-banner { position: fixed; top: 0; left: 0; right: 0;
   background: var(--surface); border-bottom: 1px solid var(--border);
@@ -155,10 +159,6 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 #update-reload { background: none; border: 1px solid var(--ir); color: var(--ir);
   font-family: 'DM Mono', monospace; font-size: 11px; font-weight: 700;
   padding: 3px 10px; border-radius: 6px; cursor: pointer; touch-action: manipulation; }
-/* Simulation card */
-.pill-card--sim { border-color: rgba(91,184,245,.2); border-style: dashed; opacity: .8; }
-.sim-label { font-family: 'DM Mono', monospace; font-size: 10px; color: var(--dim);
-  text-transform: uppercase; letter-spacing: .06em; margin-top: 6px; }
 </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -144,6 +144,17 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
   font-size: 12px; font-weight: 700; cursor: pointer; padding: 0; letter-spacing: .06em;
   transition: transform .15s ease-out; }
 #undo-btn.pressing, #undo-btn:active { transform: scale(0.88); transition: transform .08s ease-in; }
+/* Update banner */
+#update-banner { position: fixed; top: 0; left: 0; right: 0;
+  background: var(--surface); border-bottom: 1px solid var(--border);
+  padding: 10px 20px; padding-top: calc(env(safe-area-inset-top, 0px) + 10px);
+  display: none; align-items: center; justify-content: space-between;
+  font-family: 'DM Mono', monospace; font-size: 11px; color: var(--toast-text);
+  z-index: 200; }
+#update-banner.visible { display: flex; }
+#update-reload { background: none; border: 1px solid var(--ir); color: var(--ir);
+  font-family: 'DM Mono', monospace; font-size: 11px; font-weight: 700;
+  padding: 3px 10px; border-radius: 6px; cursor: pointer; touch-action: manipulation; }
 /* Simulation card */
 .pill-card--sim { border-color: rgba(91,184,245,.2); border-style: dashed; opacity: .8; }
 .sim-label { font-family: 'DM Mono', monospace; font-size: 10px; color: var(--dim);
@@ -151,6 +162,10 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 </style>
 </head>
 <body>
+<div id="update-banner">
+  <span>update available</span>
+  <button id="update-reload" onclick="location.reload()">RELOAD</button>
+</div>
 <div id="app">
   <div class="header">
     <div class="title">Medikinetics</div>
@@ -862,7 +877,11 @@ if ('serviceWorker' in navigator) {
   navigator.serviceWorker.addEventListener('message', e => {
     if (e.data?.type === 'VERSION') {
       const el = document.getElementById('version-label');
+      const prev = el?.textContent;
       if (el) el.textContent = e.data.version;
+      if (prev && prev !== e.data.version) {
+        document.getElementById('update-banner')?.classList.add('visible');
+      }
     }
   });
 }

--- a/sw.js
+++ b/sw.js
@@ -140,7 +140,12 @@ self.addEventListener('fetch', event => {
       const cached = await caches.match(event.request);
       if (cached) return cached;
 
-      return await fetch(event.request);
+      const response = await fetch(event.request);
+      if (response.ok) {
+        const cache = await caches.open(CACHE);
+        cache.put(event.request, response.clone()); // fire-and-forget
+      }
+      return response;
     } catch (error) {
       return new Response('', { status: 504, statusText: 'Offline' });
     }


### PR DESCRIPTION
## Summary

- **Font offline support** — `sw.js` non-navigation fetch handler now writes successful responses to cache (fire-and-forget `cache.put` after returning the response). Google Fonts CSS and WOFF2 files fetched on first online visit are cached; subsequent offline opens serve them from cache. No install-time complexity, no User-Agent font-format guessing.

- **Update available banner** — When a new SW activates while the app is open, the VERSION postMessage fires with the new version string. The client compares it to the current `#version-label` value; if they differ, `#update-banner` becomes visible: `update available · [RELOAD]`. Banner respects `env(safe-area-inset-top)` for notch displays.

The banner condition is `prev && prev !== e.data.version` — on the very first SW activate for the current session (normal startup, versions match), no banner. Only fires when a new SW takes over a live page with a different version.

## Test plan

- [ ] Load app online → close network → reload → fonts render correctly (DM Mono, Space Grotesk)
- [ ] In SW DevTools: bump `VERSION` string → unregister → reload → banner appears; tapping RELOAD loads the new version
- [ ] Normal reload with no SW update → no banner
- [ ] Version label shows correct version after SW activates
- [ ] Banner top edge accounts for iPhone notch (safe-area-inset-top)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)