### PR TITLE
chore: polish — prefers-reduced-motion, CSS contain, gstatic preconnect, noscript

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,13 @@
 <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Space+Grotesk:wght@600;700&display=swap" rel="stylesheet">
 <style>
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; -webkit-tap-highlight-color: transparent; }
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}
 :root {
   --bg: #080d17; --surface: #0f1623; --border: #1a2235;
   --muted: #2d3f57; --dim: #3a5070; --soft: #4a6080;
@@ -149,24 +156,14 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 .pill-card--sim { border-color: rgba(91,184,245,.2); border-style: dashed; opacity: .8; }
 .sim-label { font-family: 'DM Mono', monospace; font-size: 10px; color: var(--dim);
   text-transform: uppercase; letter-spacing: .06em; margin-top: 6px; }
-/* Honor user motion preference — drop animations and transitions */
-@media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after {
-    transition-duration: 0.01ms !important;
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-  }
-}
 </style>
 </head>
 <body>
-<noscript>
-  <div style="padding: 32px 24px; text-align: center; font-family: system-ui, sans-serif;">
-    <h1 style="font-size: 18px; margin-bottom: 12px;">Medikinetics needs JavaScript</h1>
-    <p style="color: #8ba3be; line-height: 1.5;">This app runs entirely in your browser and stores doses locally. Enable JavaScript to continue.</p>
-  </div>
-</noscript>
 <div id="app">
+  <noscript>
+    <h1 style="font-size: 18px; margin-bottom: 12px; text-align: center;">Medikinetics needs JavaScript</h1>
+    <p style="color: #8ba3be; line-height: 1.5; text-align: center;">This app runs entirely in your browser and stores doses locally. Enable JavaScript to continue.</p>
+  </noscript>
   <div class="header">
     <div class="title">Medikinetics</div>
     <div class="sub"><span id="version-label" style="opacity:.4">20260430.0003</span></div>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 <meta name="theme-color" content="#080d17">
 <title>Medikinetics</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Space+Grotesk:wght@600;700&display=swap" rel="stylesheet">
 <style>
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; -webkit-tap-highlight-color: transparent; }
@@ -96,7 +97,7 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 .fed-track--fed .fed-thumb { transform: translateX(16px); background: #4ecb8d; }
 /* Card */
 .pill-card { background: var(--surface); border: 1px solid var(--border);
-  border-radius: 16px; padding: 16px; margin-bottom: 12px; }
+  border-radius: 16px; padding: 16px; margin-bottom: 12px; contain: layout style; }
 .card-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 14px; }
 .card-head-left { display: flex; align-items: baseline; gap: 8px; }
 .card-type { font-size: 15px; font-weight: 700; }
@@ -112,7 +113,7 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 .fill-bar { height: 100%; border-radius: 3px; transition: width 0.3s ease; }
 /* Log */
 .log-row { display: flex; align-items: center; gap: 8px;
-  padding: 12px 0; border-bottom: 1px solid var(--surface); }
+  padding: 12px 0; border-bottom: 1px solid var(--surface); contain: layout style; }
 .log-row.expired { opacity: .3; }
 .log-type { font-size: 13px; font-weight: 700; min-width: 36px; }
 .log-mg { font-family: 'DM Mono', monospace; font-size: 12px; color: var(--soft); min-width: 44px; }
@@ -148,9 +149,23 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 .pill-card--sim { border-color: rgba(91,184,245,.2); border-style: dashed; opacity: .8; }
 .sim-label { font-family: 'DM Mono', monospace; font-size: 10px; color: var(--dim);
   text-transform: uppercase; letter-spacing: .06em; margin-top: 6px; }
+/* Honor user motion preference — drop animations and transitions */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}
 </style>
 </head>
 <body>
+<noscript>
+  <div style="padding: 32px 24px; text-align: center; font-family: system-ui, sans-serif;">
+    <h1 style="font-size: 18px; margin-bottom: 12px;">Medikinetics needs JavaScript</h1>
+    <p style="color: #8ba3be; line-height: 1.5;">This app runs entirely in your browser and stores doses locally. Enable JavaScript to continue.</p>
+  </div>
+</noscript>
 <div id="app">
   <div class="header">
     <div class="title">Medikinetics</div>


### PR DESCRIPTION
## Summary

Four small polish improvements that don't fit the named buckets but raise the floor on accessibility, perceived performance, and graceful degradation:

- **`prefers-reduced-motion`** — `@media (prefers-reduced-motion: reduce)` collapses every transition and animation to 0.01ms. Motion-sensitive users get a static UI; animations still technically complete so any future `transitionend` listeners would fire correctly.
- **`contain: layout style`** on `.pill-card` and `.log-row` — tells the browser that changes inside a card cannot affect layout outside it. When `updatePillCardBody` updates a phase fill width or the 30s tick refreshes timers, the browser can skip layout for siblings. No visual change. Paint containment is deliberately omitted so the press-feedback `scale(0.91)` transform isn't clipped.
- **Preconnect to `fonts.gstatic.com`** — the existing `preconnect` only covers `fonts.googleapis.com` (CSS); the WOFF2 binaries live on a different origin. Adding the second `preconnect` saves the TLS handshake on first paint.
- **`<noscript>` fallback** — JS-disabled visitors see a brief explanation instead of a blank dark rectangle.

## Test plan

- [ ] System Settings → Accessibility → Motion (Reduce): app renders without transitions; fed toggle still works (slides in one frame)
- [ ] First load on a cleared cache: fonts render slightly faster (subjective)
- [ ] 30s tick with multiple active pill cards: no visible jank
- [ ] Disable JS in Safari: noscript message visible

🤖 Generated with [Claude Code](https://claude.ai/claude-code)