### PR TITLE
docs: cross-reference comments tying sw.js VERSION to #version-label

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,6 +154,7 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 <div id="app">
   <div class="header">
     <div class="title">Medikinetics</div>
+    <!-- Static fallback shown until SW broadcasts VERSION; keep in sync with sw.js VERSION. -->
     <div class="sub"><span id="version-label" style="opacity:.4">20260430.0003</span></div>
   </div>
 

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,8 @@
 // Medikinetics Service Worker v5
+// VERSION drives the cache key AND the version label shown in index.html.
+// When bumping the date stamp here, also update the static fallback in
+// index.html's #version-label span — the update banner will fire for any
+// drift but a matched pair keeps the first-load label correct.
 const VERSION = 'medikinetics-20260430.0003';
 const CACHE = VERSION;
 


### PR DESCRIPTION
## Summary

The SW `VERSION` constant and the `#version-label` static fallback in `index.html` must match to produce the correct first-load label (before the SW activate message arrives). A drift triggers the update banner, but a matched pair is the desired steady state. Both files now carry a comment pointing at the other.

No code changes; comments only.

## Test plan

- [ ] Comments render where expected
- [ ] First-load label still shows the static value before SW message

🤖 Generated with [Claude Code](https://claude.ai/claude-code)