### PR TITLE
fix: automate version stamping so the header date stays current

### DIFF
--- a/.github/workflows/version-stamp.yml
+++ b/.github/workflows/version-stamp.yml
@@ -1,0 +1,42 @@
+name: Stamp version on push
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  stamp:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute version
+        id: ver
+        run: |
+          NEW_DATE=$(echo "${{ github.event.head_commit.timestamp }}" | sed 's/T.*//' | tr -d '-')
+          NEW_VER="${NEW_DATE}.0001"
+          echo "new_ver=${NEW_VER}" >> "$GITHUB_OUTPUT"
+          echo "new_full=medikinetics-${NEW_VER}" >> "$GITHUB_OUTPUT"
+
+      - name: Patch sw.js
+        run: |
+          sed -i "s/const VERSION = 'medikinetics-[0-9]\{8\}\.[0-9]\{4\}';/const VERSION = '${{ steps.ver.outputs.new_full }}';/" sw.js
+
+      - name: Patch index.html
+        run: |
+          sed -i 's/\(<span id="version-label"[^>]*>\)[0-9]\{8\}\.[0-9]\{4\}\(<\/span>\)/\1${{ steps.ver.outputs.new_ver }}\2/' index.html
+
+      - name: Commit if changed
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --quiet && echo "No change." && exit 0
+          git add sw.js index.html
+          git commit -m "chore: stamp version ${{ steps.ver.outputs.new_ver }} [skip ci]"
+          git push

--- a/index.html
+++ b/index.html
@@ -186,8 +186,8 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
   </noscript>
   <div class="header">
     <div class="title">Medikinetics</div>
-    <!-- Static fallback shown until SW broadcasts VERSION; keep in sync with sw.js VERSION. -->
-    <div class="sub"><span id="version-label" style="opacity:.4">20260430.0003</span></div>
+    <!-- Static fallback shown until SW broadcasts VERSION; kept in sync with sw.js VERSION by version-stamp.yml. -->
+    <div class="sub"><span id="version-label" style="opacity:.4">20260524.0001</span></div>
   </div>
 
   <div class="stats-row">

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,9 @@
 // Medikinetics Service Worker v5
 // VERSION drives the cache key AND the version label shown in index.html.
-// When bumping the date stamp here, also update the static fallback in
-// index.html's #version-label span — the update banner will fire for any
-// drift but a matched pair keeps the first-load label correct.
-const VERSION = 'medikinetics-20260430.0003';
+// Do not edit VERSION manually — .github/workflows/version-stamp.yml updates
+// both this constant and the #version-label fallback in index.html on every
+// push to main.
+const VERSION = 'medikinetics-20260524.0001';
 const CACHE = VERSION;
 
 const APP_ROOT = self.registration.scope;


### PR DESCRIPTION
## Summary

- The app header showed `20260430.0003` (April 30) even though it's now May 24 — the version was manually maintained and nobody was updating it
- Corrects the version to `20260524.0001` right now
- Adds `.github/workflows/version-stamp.yml` so the date is automatically patched on every future push to `main` — no manual step required

## How it works

On each push to `main`, the workflow:
1. Reads the UTC date from the commit timestamp
2. Runs `sed` to update `const VERSION` in `sw.js` and the `#version-label` fallback in `index.html`
3. Commits the change with `[skip ci]` (plus an actor guard) to prevent an infinite trigger loop

## Test plan

- [ ] After merge, check the GitHub Actions tab — `Stamp version on push` should run and produce a commit like `chore: stamp version 20260524.0001 [skip ci]`
- [ ] Open the live app — header should show today's date
- [ ] Push any future change to `main` — confirm the workflow updates the version to the new date automatically

https://claude.ai/code/session_01LcsZVhLmAha14j5PzMDtqh

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcsZVhLmAha14j5PzMDtqh)_