### PR TITLE
Improve graph scrubbing tooltip UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,9 +95,11 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
   text-transform: uppercase; letter-spacing: .1em; }
 #chart-svg { width: 100%; display: block; overflow: visible; }
 .chart-tooltip { position: absolute; background: var(--tooltip-bg); border: 1px solid var(--border);
-  border-radius: 8px; padding: 8px 12px; pointer-events: none; display: none; z-index: 10; }
+  border-radius: 8px; padding: 8px 12px; pointer-events: none; display: none; z-index: 10;
+  min-width: 96px; text-align: center; white-space: nowrap;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.45); }
 .chart-tooltip .tt-time { font-family: 'DM Mono', monospace; font-size: 11px; color: var(--dim); }
-.chart-tooltip .tt-val { font-family: 'DM Mono', monospace; font-size: 14px; color: var(--ir); margin-top: 2px; }
+.chart-tooltip .tt-val { font-family: 'DM Mono', monospace; font-size: 14px; color: var(--ir); margin-top: 2px; font-variant-numeric: tabular-nums; }
 .chart-tooltip .tt-unit { font-size: 10px; color: var(--dim); margin-left: 4px; }
 /* Dose buttons */
 .dose-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; margin-bottom: 8px; }
@@ -578,9 +580,12 @@ function _showTooltip(clientX, clientY) {
   }
   el.ttTime.textContent = fmt(closest.ts);
   el.ttVal.textContent  = closest.total.toFixed(1);
-  const tLeft = Math.min(clientX - rect.left + 8, rect.width - 120);
+  const TOOLTIP_Y_OFFSET = 90;
+  const ttW = el.tooltip.offsetWidth || 96;
+  const rawLeft = clientX - rect.left - ttW / 2;
+  const tLeft = Math.max(4, Math.min(rawLeft, rect.width - ttW - 4));
   el.tooltip.style.left = tLeft + 'px';
-  el.tooltip.style.top  = Math.max(4, clientY - rect.top - 60) + 'px';
+  el.tooltip.style.top  = Math.max(4, clientY - rect.top - TOOLTIP_Y_OFFSET) + 'px';
   el.tooltip.style.display = 'block';
   if (hideTimer) clearTimeout(hideTimer);
 }


### PR DESCRIPTION
## Summary

- **Finger occlusion fix**: Vertical offset increased from 60px to 90px, and tooltip is now centered horizontally over the touch point (was 8px right of finger) — the standard mobile tooltip convention
- **Stable tooltip size**: Added `min-width: 96px`, `white-space: nowrap`, and `font-variant-numeric: tabular-nums` so the tooltip box doesn't jump in size as values change while scrubbing
- **Accurate edge clamping**: Replaced the hardcoded `120px` width sentinel with `el.tooltip.offsetWidth` so boundary math stays correct as content varies
- **Visual polish**: Added `box-shadow` for depth against the dark chart background

## Test plan

- [ ] Open in mobile emulation (Chrome DevTools → iPhone 14) — tap and drag on the graph; tooltip should appear clearly above the finger with no occlusion
- [ ] Scrub between a low reading (e.g. "0.0") and a peak (e.g. "12.3") — tooltip box should not resize
- [ ] Scrub to the left and right edges — tooltip should clamp inside the chart without overflowing
- [ ] Test on desktop mouse — tooltip should follow cursor centered above it

https://claude.ai/code/session_015sUtGoUwhcr12u1sUEtZkY

---
_Generated by [Claude Code](https://claude.ai/code/session_015sUtGoUwhcr12u1sUEtZkY)_